### PR TITLE
Release v0.1.0-alpha.6 Add electron to cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+cache:
+  directories:
+  - electron/cache/v0.35.0
 before_script:
   - npm install -g gulp
 node_js:


### PR DESCRIPTION
Travis documentation says, it supports caching folder. Lets check.. it may solve the download rate limit in github.